### PR TITLE
NXP-16336: fix tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.nuxeo</groupId>

--- a/src/test/java/org/nuxeo/binary/metadata/test/TestBinaryMetadataOperation.java
+++ b/src/test/java/org/nuxeo/binary/metadata/test/TestBinaryMetadataOperation.java
@@ -29,14 +29,10 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.nuxeo.binary.metadata.api.BinaryMetadataService;
 import org.nuxeo.binary.metadata.internals.operations.ReadMetadataFromBinary;
-import org.nuxeo.binary.metadata.internals.operations
-        .ReadMetadataFromBinaryToContext;
-import org.nuxeo.binary.metadata.internals.operations
-        .TriggerMetadataMappingOnDocument;
-import org.nuxeo.binary.metadata.internals.operations
-        .WriteMetadataToBinaryFromContext;
-import org.nuxeo.binary.metadata.internals.operations
-        .WriteMetadataToBinaryFromDocument;
+import org.nuxeo.binary.metadata.internals.operations.ReadMetadataFromBinaryToContext;
+import org.nuxeo.binary.metadata.internals.operations.TriggerMetadataMappingOnDocument;
+import org.nuxeo.binary.metadata.internals.operations.WriteMetadataToBinaryFromContext;
+import org.nuxeo.binary.metadata.internals.operations.WriteMetadataToBinaryFromDocument;
 import org.nuxeo.ecm.automation.AutomationService;
 import org.nuxeo.ecm.automation.OperationContext;
 import org.nuxeo.ecm.automation.OperationException;
@@ -140,7 +136,8 @@ public class TestBinaryMetadataOperation {
 
         operationContext.setInput(blob);
         operationContext.setCoreSession(session);
-        Blob newBlob = (Blob) automationService.run(operationContext, WriteMetadataToBinaryFromContext.ID, jpgParameters);
+        Blob newBlob = (Blob) automationService.run(operationContext, WriteMetadataToBinaryFromContext.ID,
+                jpgParameters);
 
         // Check the content
         blobProperties = binaryMetadataService.readMetadata(newBlob, false);

--- a/src/test/java/org/nuxeo/binary/metadata/test/TestBinaryMetadataSyncListener.java
+++ b/src/test/java/org/nuxeo/binary/metadata/test/TestBinaryMetadataSyncListener.java
@@ -43,7 +43,9 @@ import org.nuxeo.runtime.test.runner.LocalDeploy;
  */
 @RunWith(FeaturesRunner.class)
 @Features(BinaryMetadataFeature.class)
-@Deploy({ "org.nuxeo.ecm.platform.picture.api", "org.nuxeo.ecm.platform.picture.core" })
+@Deploy({ "org.nuxeo.ecm.platform.picture.api", "org.nuxeo.ecm.platform.picture.core",
+        "org.nuxeo.ecm.platform.picture.convert", "org.nuxeo.ecm.platform.rendition.core",
+        "org.nuxeo.ecm.automation.core" })
 @LocalDeploy({ "org.nuxeo.binary.metadata:binary-metadata-contrib-test.xml",
         "org.nuxeo.binary.metadata:binary-metadata-contrib-pdf-test.xml" })
 @RepositoryConfig(cleanup = Granularity.METHOD)

--- a/src/test/resources/binary-metadata-contrib-test.xml
+++ b/src/test/resources/binary-metadata-contrib-test.xml
@@ -1,9 +1,7 @@
 <component name="org.nuxeo.binary.metadata.contribs.tests.rules">
 
   <require>org.nuxeo.binary.metadata.contribs.tests.pdf</require>
-
-  <extension target="org.nuxeo.binary.metadata"
-             point="metadataRules">
+  <extension target="org.nuxeo.binary.metadata" point="metadataRules">
     <rule id="default" order="0" enabled="true" async="false">
       <metadataMappings>
         <metadataMapping-id>PDF</metadataMapping-id>
@@ -23,8 +21,7 @@
     </rule>
   </extension>
 
-  <extension target="org.nuxeo.ecm.platform.actions.ActionService"
-             point="filters">
+  <extension target="org.nuxeo.ecm.platform.actions.ActionService" point="filters">
     <filter id="hasFileType">
       <rule grant="true">
         <type>File</type>


### PR DESCRIPTION
For review.

This fixes a lot of noisy errors in the logs.
Please look at fixing those too:
- ```
  ERROR [CoreFeature] There are 4 open session(s) at tear down; it seems the test leaked 4 session(s).
  ```
- ```
  ERROR [ExifToolProcessor] There was an error executing the following command: /bin/sh -c exiftool -m -SourceURL=ladresse\ idéale  "/tmp/nxblob-1645302064167568740.mp3". 
  Warning: Sorry, SourceURL is not writable
  ```
- ```
  WARN  [ResourcePublisherService$ResourcesRegistry] Already registered org.nuxeo:name=BinaryMetadataService.handleSyncUpdate,type=Stopwatch,management=metric, skipping
  java.lang.Throwable: Stack trace
  at org.nuxeo.runtime.management.ResourcePublisherService$ResourcesRegistry.doRegisterResource(ResourcePublisherService.java:216)
  at org.nuxeo.runtime.management.ResourcePublisherService$ResourcesRegistry.doRegisterResource(ResourcePublisherService.java:155)
  at org.nuxeo.runtime.management.ResourcePublisherService.registerResource(ResourcePublisherService.java:291)
  at org.nuxeo.runtime.management.metrics.MetricRegister.registerMXBean(MetricRegister.java:47)
  at org.nuxeo.runtime.management.metrics.MetricRegisteringCallback.register(MetricRegisteringCallback.java:69)
  at org.nuxeo.runtime.management.metrics.MetricRegisteringCallback.simonCreated(MetricRegisteringCallback.java:47)
  at org.javasimon.CompositeCallback.simonCreated(CompositeCallback.java:146)
  at org.javasimon.EnabledManager.getOrCreateSimon(EnabledManager.java:109)
  at org.javasimon.EnabledManager.getStopwatch(EnabledManager.java:77)
  at org.javasimon.SwitchingManager.getStopwatch(SwitchingManager.java:42)
  at org.javasimon.SimonManager.getStopwatch(SimonManager.java:110)
  at org.nuxeo.runtime.management.metrics.MetricInvocationHandler.getStopwatch(MetricInvocationHandler.java:65)
  at org.nuxeo.runtime.management.metrics.MetricInvocationHandler.invoke(MetricInvocationHandler.java:72)
  at com.sun.proxy.$Proxy33.handleSyncUpdate(Unknown Source)
  at org.nuxeo.binary.metadata.internals.listeners.BinaryMetadataSyncListener.handleEvent(BinaryMetadataSyncListener.java:57)
  at org.nuxeo.ecm.core.event.impl.EventServiceImpl.fireEvent(EventServiceImpl.java:191)
  at org.nuxeo.ecm.core.api.AbstractSession.notifyEvent(AbstractSession.java:264)
  at org.nuxeo.ecm.core.api.AbstractSession.saveDocument(AbstractSession.java:1408)
  at org.nuxeo.binary.metadata.test.TestBinaryMetadataAsyncListener.testListener(TestBinaryMetadataAsyncListener.java:73)
  at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
  at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
  at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
  at java.lang.reflect.Method.invoke(Method.java:497)
  at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:47)
  at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
  at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:44)
  at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
  at org.nuxeo.runtime.test.runner.FeaturesRunner$15.evaluate(FeaturesRunner.java:467)
  at org.nuxeo.runtime.test.runner.FeaturesRunner$BeforeMethodRunStatement.evaluate(FeaturesRunner.java:346)
  at org.nuxeo.runtime.test.runner.FeaturesRunner$BeforeSetupStatement.evaluate(FeaturesRunner.java:362)
  at org.nuxeo.runtime.test.runner.FeaturesRunner$AfterMethodRunStatement.evaluate(FeaturesRunner.java:393)
  at org.nuxeo.runtime.test.runner.FeaturesRunner$AfterTeardownStatement.evaluate(FeaturesRunner.java:412)
  at org.nuxeo.runtime.test.runner.FeaturesRunner$RulesFactory$1.evaluate(FeaturesRunner.java:525)
  at org.nuxeo.runtime.test.runner.RuntimeDeployment$DeploymentStatement.evaluate(RuntimeDeployment.java:265)
  at org.nuxeo.runtime.test.runner.RuntimeFeature$2$1.evaluate(RuntimeFeature.java:124)
  at org.junit.rules.RunRules.evaluate(RunRules.java:20)
  at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:271)
  at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:70)
  at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:50)
  at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
  at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
  at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
  at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
  at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
  at org.nuxeo.runtime.test.runner.FeaturesRunner$AfterClassStatement.evaluate(FeaturesRunner.java:285)
  at org.nuxeo.runtime.test.runner.FeaturesRunner$RulesFactory$1.evaluate(FeaturesRunner.java:525)
  at org.nuxeo.runtime.test.runner.FeaturesRunner$BeforeClassStatement.evaluate(FeaturesRunner.java:268)
  at org.junit.rules.RunRules.evaluate(RunRules.java:20)
  at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
  at org.eclipse.jdt.internal.junit4.runner.JUnit4TestReference.run(JUnit4TestReference.java:50)
  at org.eclipse.jdt.internal.junit.runner.TestExecution.run(TestExecution.java:38)
  at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.runTests(RemoteTestRunner.java:459)
  at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.runTests(RemoteTestRunner.java:675)
  at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.run(RemoteTestRunner.java:382)
  at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.main(RemoteTestRunner.java:192)
  WARN  [ResourcePublisherService$ResourcesRegistry] Already registered org.nuxeo:name=BinaryMetadataService.handleUpdate,type=Stopwatch,management=metric, skipping
  java.lang.Throwable: Stack trace
  at org.nuxeo.runtime.management.ResourcePublisherService$ResourcesRegistry.doRegisterResource(ResourcePublisherService.java:216)
  at org.nuxeo.runtime.management.ResourcePublisherService$ResourcesRegistry.doRegisterResource(ResourcePublisherService.java:155)
  at org.nuxeo.runtime.management.ResourcePublisherService.registerResource(ResourcePublisherService.java:291)
  at org.nuxeo.runtime.management.metrics.MetricRegister.registerMXBean(MetricRegister.java:47)
  at org.nuxeo.runtime.management.metrics.MetricRegisteringCallback.register(MetricRegisteringCallback.java:69)
  at org.nuxeo.runtime.management.metrics.MetricRegisteringCallback.simonCreated(MetricRegisteringCallback.java:47)
  at org.javasimon.CompositeCallback.simonCreated(CompositeCallback.java:146)
  at org.javasimon.EnabledManager.getOrCreateSimon(EnabledManager.java:109)
  at org.javasimon.EnabledManager.getStopwatch(EnabledManager.java:77)
  at org.javasimon.SwitchingManager.getStopwatch(SwitchingManager.java:42)
  at org.javasimon.SimonManager.getStopwatch(SimonManager.java:110)
  at org.nuxeo.runtime.management.metrics.MetricInvocationHandler.getStopwatch(MetricInvocationHandler.java:65)
  at org.nuxeo.runtime.management.metrics.MetricInvocationHandler.invoke(MetricInvocationHandler.java:72)
  at com.sun.proxy.$Proxy33.handleUpdate(Unknown Source)
  at org.nuxeo.binary.metadata.internals.BinaryMetadataWork.work(BinaryMetadataWork.java:77)
  at org.nuxeo.ecm.core.work.AbstractWork.runWorkWithTransaction(AbstractWork.java:340)
  at org.nuxeo.ecm.core.work.AbstractWork.runWorkWithTransactionAndCheckExceptions(AbstractWork.java:301)
  at org.nuxeo.ecm.core.work.AbstractWork.run(AbstractWork.java:272)
  at org.nuxeo.ecm.core.work.WorkHolder.run(WorkHolder.java:52)
  at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
  at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
  at java.lang.Thread.run(Thread.java:745)`
  ```
